### PR TITLE
Pass options thru to Readable constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "feature": "~0.1.3"
   },
   "dependencies": {
+    "extend.js": "0.0.1",
     "mime-component": "0.0.1"
   }
 }

--- a/read.js
+++ b/read.js
@@ -5,17 +5,17 @@ var Readable = require('stream').Readable;
 var util = require('util');
 var reExtension = /^.*\.(\w+)$/;
 var mime = require('mime-component');
+var extend = require('extend.js');
 
-
-function FileReadStream(file) {
+function FileReadStream(file, opts) {
   if (! (this instanceof FileReadStream)) {
     return new FileReadStream(file);
   }
 
   // inherit readable
-  Readable.call(this, {
+  Readable.call(this, extend({
     objectMode: true
-  });
+  }, opts));
 
   // save the read offset
   this._offset = 0;


### PR DESCRIPTION
It's good practice to allow the user to configure the underlying Readable stream by passing options through.
