### PR TITLE
remove mime type from metadata; include extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "extend.js": "0.0.1",
-    "mime-component": "0.0.1",
     "typedarray-to-buffer": "^1.0.3"
   }
 }

--- a/read.js
+++ b/read.js
@@ -4,7 +4,6 @@
 var Readable = require('stream').Readable;
 var util = require('util');
 var reExtension = /^.*\.(\w+)$/;
-var mime = require('mime-component');
 var extend = require('extend.js');
 var toBuffer = require('typedarray-to-buffer');
 
@@ -29,7 +28,7 @@ function FileReadStream(file, opts) {
   this._metadata = {
     name: file.name,
     size: file.size,
-    type: mime.lookup(file.name.replace(reExtension, '$1'))
+    extension: file.name.replace(reExtension, '$1')
   };
 
   // create the reader


### PR DESCRIPTION
this is to remove the mime-component dependency which adds 35kb to the
bundle size.

this should bump the major version since it’s a breaking change. it’s
pretty easy to migrate to the new version by simply requiring
`mime-component` and calling `mime.lookup(file.extension)`.

closes #7 
