### PR TITLE
Remove objectMode from FileReadStream

### DIFF
--- a/read.js
+++ b/read.js
@@ -1,7 +1,6 @@
 var Readable = require('stream').Readable;
 var inherits = require('inherits');
 var reExtension = /^.*\.(\w+)$/;
-var extend = require('extend.js');
 var toBuffer = require('typedarray-to-buffer');
 
 function FileReadStream(file, opts) {
@@ -12,9 +11,7 @@ function FileReadStream(file, opts) {
   opts = opts || {};
 
   // inherit readable
-  Readable.call(this, extend({
-    objectMode: true
-  }, opts));
+  Readable.call(this, opts));
 
   // save the read offset
   this._offset = 0;


### PR DESCRIPTION
I believe we needed objectMode in the past because the readable stream
could emit data that was ArrayBuffer or Uint8Array, etc.

Now that we always emit data as Buffers, objectMode is not necessary.

This PR doesn't change the FileWriteStream case since users might want
to push various types (besides strings and Buffers) to the stream.