### PR TITLE
modernize

### DIFF
--- a/examples/drag-n-drop.js
+++ b/examples/drag-n-drop.js
@@ -1,35 +1,35 @@
-var crel = require('crel');
-var detect = require('feature/detect');
-var dnd = require('drag-and-drop-files');
-var img = crel('img');
-var video = crel('video', { autoplay: true });
-var FileReadStream = require('../read');
-var FileWriteStream = require('../write');
+var crel = require('crel')
+var detect = require('feature/detect')
+var dnd = require('drag-and-drop-files')
+var img = crel('img')
+var video = crel('video', { autoplay: true })
+var FileReadStream = require('../read')
+var FileWriteStream = require('../write')
 
-function upload(files) {
-  var queue = [].concat(files);
+function upload (files) {
+  var queue = [].concat(files)
 
-  function sendNext() {
-    var writer = new FileWriteStream();
-    var next = queue.shift();
+  function sendNext () {
+    var writer = new FileWriteStream()
+    var next = queue.shift()
 
-    console.log('sending file');
-    new FileReadStream(next).pipe(writer).on('file', function(file) {
-      console.log('file created: ', file);
-      img.src = detect('URL').createObjectURL(file);
+    console.log('sending file')
+    new FileReadStream(next).pipe(writer).on('file', function (file) {
+      console.log('file created: ', file)
+      img.src = detect('URL').createObjectURL(file)
       // video.src = detect('URL').createObjectURL(next);
 
       if (queue.length > 0) {
-        sendNext();
+        sendNext()
       }
-    });
+    })
   }
 
-  sendNext();
+  sendNext()
 }
 
-dnd(document.body, upload);
+dnd(document.body, upload)
 
-document.body.appendChild(crel('style', 'body, html { margin: 0; width: 100%; height: 100% }'));
-document.body.appendChild(img);
-document.body.appendChild(video);
+document.body.appendChild(crel('style', 'body, html { margin: 0; width: 100%; height: 100% }'))
+document.body.appendChild(img)
+document.body.appendChild(video)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /* jshint node: true */
-'use strict';
+'use strict'
 
 /**
   # filestream
@@ -19,5 +19,5 @@
   <<< examples/drag-n-drop.js
 **/
 
-exports.read = require('./read');
-exports.write = require('./write');
+exports.read = require('./read')
+exports.write = require('./write')

--- a/package.json
+++ b/package.json
@@ -24,16 +24,14 @@
   },
   "homepage": "https://github.com/DamonOehlman/filestream",
   "devDependencies": {
-    "crel": "^2.1.8",
+    "crel": "^3.1.0",
     "drag-and-drop-files": "0.0.1",
-    "feature": "^1.0.0",
-    "tape": "^4.0.0",
-    "zuul": "^3.0.0"
+    "feature": "^1.0.1",
+    "tape": "^4.9.1",
+    "zuul": "^3.12.0"
   },
   "dependencies": {
-    "inherits": "^2.0.1",
-    "readable-stream": "^2.0.5",
-    "typedarray-to-buffer": "^3.0.0",
-    "xtend": "^4.0.1"
+    "readable-stream": "^3.0.3",
+    "typedarray-to-buffer": "^3.0.0"
   }
 }

--- a/read.js
+++ b/read.js
@@ -1,92 +1,82 @@
-var Readable = require('readable-stream').Readable;
-var inherits = require('inherits');
-var reExtension = /^.*\.(\w+)$/;
-var toBuffer = require('typedarray-to-buffer');
+const { Readable } = require('readable-stream')
+const toBuffer = require('typedarray-to-buffer')
 
-function FileReadStream(file, opts) {
-  var readStream = this;
-  if (! (this instanceof FileReadStream)) {
-    return new FileReadStream(file, opts);
-  }
-  opts = opts || {};
+class FileReadStream extends Readable {
+  constructor (file, opts = {}) {
+    super()
 
-  // inherit readable
-  Readable.call(this, opts);
+    // save the read offset
+    this._offset = 0
+    this._ready = false
+    this._file = file
+    this._size = file.size
+    this._chunkSize = opts.chunkSize || Math.max(this._size / 1000, 200 * 1024)
 
-  // save the read offset
-  this._offset = 0;
-  this._ready = false;
-  this._file = file;
-  this._size = file.size;
-  this._chunkSize = opts.chunkSize || Math.max(this._size / 1000, 200 * 1024);
+    // create the reader
+    const reader = new FileReader()
 
-  // create the reader
-  this.reader = new FileReader();
-
-  // generate the header blocks that we will send as part of the initial payload
-  this._generateHeaderBlocks(file, opts, function(err, blocks) {
-    // if we encountered an error, emit it
-    if (err) {
-      return readStream.emit('error', err);
+    reader.onload = () => {
+      // get the data chunk
+      this.push(toBuffer(reader.result))
+    }
+    reader.onerror = () => {
+      this.emit('error', reader.error)
     }
 
-    // push the header blocks out to the stream
-    if (Array.isArray(blocks)) {
-      blocks.forEach(function (block) {
-        readStream.push(block);
-      });
+    this.reader = reader
+
+    // generate the header blocks that we will send as part of the initial payload
+    this._generateHeaderBlocks(file, opts, (err, blocks) => {
+      // if we encountered an error, emit it
+      if (err) {
+        return this.emit('error', err)
+      }
+
+      // push the header blocks out to the stream
+      if (Array.isArray(blocks)) {
+        blocks.forEach(block => this.push(block))
+      }
+
+      this._ready = true
+      this.emit('_ready')
+    })
+  }
+
+  _generateHeaderBlocks (file, opts, callback) {
+    callback(null, [])
+  }
+
+  _read () {
+    if (!this._ready) {
+      this.once('_ready', this._read.bind(this))
+      return
     }
 
-    readStream._ready = true;
-    readStream.emit('_ready');
-  });
-}
+    const startOffset = this._offset
+    let endOffset = this._offset + this._chunkSize
+    if (endOffset > this._size) endOffset = this._size
 
-inherits(FileReadStream, Readable);
-module.exports = FileReadStream;
+    if (startOffset === this._size) {
+      this.destroy()
+      this.push(null)
+      return
+    }
 
-FileReadStream.prototype._generateHeaderBlocks = function(file, opts, callback) {
-  callback(null, []);
-};
+    this.reader.readAsArrayBuffer(this._file.slice(startOffset, endOffset))
 
-FileReadStream.prototype._read = function() {
-  if (!this._ready) {
-    this.once('_ready', this._read.bind(this));
-    return;
-  }
-  var readStream = this;
-  var reader = this.reader;
-
-  var startOffset = this._offset;
-  var endOffset = this._offset + this._chunkSize;
-  if (endOffset > this._size) endOffset = this._size;
-
-  if (startOffset === this._size) {
-    this.destroy();
-    this.push(null);
-    return;
-  }
-
-  reader.onload = function() {
     // update the stream offset
-    readStream._offset = endOffset;
-
-    // get the data chunk
-    readStream.push(toBuffer(reader.result));
-  }
-  reader.onerror = function() {
-    readStream.emit('error', reader.error);
+    this._offset = endOffset
   }
 
-  reader.readAsArrayBuffer(this._file.slice(startOffset, endOffset));
-};
-
-FileReadStream.prototype.destroy = function() {
-  this._file = null;
-  if (this.reader) {
-    this.reader.onload = null;
-    this.reader.onerror = null;
-    try { this.reader.abort(); } catch (e) {};
+  destroy () {
+    this._file = null
+    if (this.reader) {
+      this.reader.onload = null
+      this.reader.onerror = null
+      try { this.reader.abort() } catch (e) {};
+    }
+    this.reader = null
   }
-  this.reader = null;
 }
+
+module.exports = FileReadStream

--- a/test/read.js
+++ b/test/read.js
@@ -1,36 +1,36 @@
-var FileReadStream = require('../').read;
-var test = require('tape');
+var FileReadStream = require('../').read
+var test = require('tape')
 
-test('read stream (3MB blob)', function(t) {
-  testReadStream(t, 3 * 1000 * 1000);
-});
+test('read stream (3MB blob)', function (t) {
+  testReadStream(t, 3 * 1000 * 1000)
+})
 
-test('read stream (30MB blob)', function(t) {
-  testReadStream(t, 30 * 1000 * 1000);
-});
+test('read stream (30MB blob)', function (t) {
+  testReadStream(t, 30 * 1000 * 1000)
+})
 
-test('read stream (300MB blob)', function(t) {
-  testReadStream(t, 300 * 1000 * 1000);
-});
+test('read stream (300MB blob)', function (t) {
+  testReadStream(t, 300 * 1000 * 1000)
+})
 
-function testReadStream(t, size) {
-  t.plan(1);
-  var data = new Buffer(size).fill('abc');
-  var blob = new Blob([ data.buffer ]);
+function testReadStream (t, size) {
+  t.plan(1)
+  var data = Buffer.alloc(size).fill('abc')
+  var blob = new Blob([ data.buffer ])
 
-  var stream = new FileReadStream(blob);
+  var stream = new FileReadStream(blob)
   stream.on('error', function (err) {
-    console.error(err);
-    t.error(err.message);
-  });
+    console.error(err)
+    t.error(err.message)
+  })
 
-  var chunks = [];
-  stream.on('data', function(chunk) {
-    chunks.push(chunk);
-  });
+  var chunks = []
+  stream.on('data', function (chunk) {
+    chunks.push(chunk)
+  })
 
-  stream.on('end', function() {
-    var combined = Buffer.concat(chunks);
-    t.deepEqual(combined, data);
-  });
+  stream.on('end', function () {
+    var combined = Buffer.concat(chunks)
+    t.deepEqual(combined, data)
+  })
 }

--- a/write.js
+++ b/write.js
@@ -1,77 +1,73 @@
-var Writable = require('readable-stream').Writable;
-var inherits = require('inherits');
-var extend = require('xtend');
-var toBuffer = require('typedarray-to-buffer');
+const { Writable } = require('readable-stream')
+const toBuffer = require('typedarray-to-buffer')
 
-function FileWriteStream(callback, opts) {
-  if (! (this instanceof FileWriteStream)) {
-    return new FileWriteStream(callback, opts);
+class FileWriteStream extends Writable {
+  constructor (callback, opts) {
+    // inherit writable
+    super(Object.assign({ decodeStrings: false }, opts))
+
+    // when the stream finishes create a file
+    this.on('finish', this._generateFile.bind(this))
+
+    // create the internal buffers storage
+    this._buffers = []
+    this._bytesreceived = 0
+    this.callback = callback
+    this.type = (opts || {}).type
   }
 
-  // inherit writable
-  Writable.call(this, extend({ decodeStrings: false }, opts));
+  _createFile () {
+    // if we have no buffers, then abort any processing
+    if (this._buffers.length === 0) {
+      return
+    }
 
-  // when the stream finishes create a file
-  this.on('finish', this._generateFile.bind(this));
+    return new File(this._buffers, '', {
+      type: this.type || ''
+    })
+  }
 
-  // create the internal buffers storage
-  this._buffers = [];
-  this._bytesreceived = 0;
-  this.callback = callback;
-  this.type = (opts || {}).type;
+  _generateFile () {
+    const file = this._createFile()
+
+    if (file) {
+      if (typeof this.callback === 'function') {
+        this.callback(file)
+      }
+
+      this.emit('file', file)
+    }
+
+    // reset the buffers and counters
+    this._buffers = []
+    this._bytesreceived = 0
+  }
+
+  _preprocess (data, callback) {
+    // pass through the data
+    callback(null, data)
+  }
+
+  _write (chunk, encoding, callback) {
+    const data = Buffer.isBuffer(chunk) ? chunk : toBuffer(chunk)
+    const writeStream = this
+
+    this._preprocess(data, (err, processed) => {
+      if (err) {
+        return callback(err)
+      }
+
+      // if the incoming data has been passed through,
+      // then add to the bytes received buffer
+      if (processed) {
+        writeStream._bytesreceived += processed.length
+        writeStream._buffers.push(processed)
+        writeStream.emit('progress', writeStream._bytesreceived)
+      }
+
+      callback()
+    })
+  }
 }
 
-inherits(FileWriteStream, Writable);
-module.exports = FileWriteStream;
-
-FileWriteStream.prototype._createFile = function() {
-  // if we have no buffers, then abort any processing
-  if (this._buffers.length === 0) {
-    return;
-  }
-
-  return new File(this._buffers, '', {
-    type: this.type || ''
-  });
-};
-
-FileWriteStream.prototype._generateFile = function() {
-  var file = this._createFile();
-
-  if (file) {
-    if (typeof this.callback == 'function') {
-      this.callback(file);
-    }
-
-    this.emit('file', file);
-  }
-
-  // reset the buffers and counters
-  this._buffers = [];
-  this._bytesreceived = 0;
-};
-
-FileWriteStream.prototype._preprocess = function(data, callback) {
-  // pass through the data
-  callback(null, data);
-};
-
-FileWriteStream.prototype._write = function(chunk, encoding, callback) {
-  var data = Buffer.isBuffer(chunk) ? chunk : toBuffer(chunk);
-  var writeStream = this;
-
-  this._preprocess(data, function(err, processed) {
-    if (err) {
-      return callback(err);
-    }
-
-    // if the incoming data has been passed through, then add to the bytes received buffer
-    if (processed) {
-      writeStream._bytesreceived += processed.length;
-      writeStream._buffers.push(processed);
-      writeStream.emit('progress', writeStream._bytesreceived);
-    }
-
-    callback();
-  });
-};
+module.exports = FileWriteStream


### PR DESCRIPTION
I updated the readable-stream to v3 and they now target node => 6, so i thought we can as well update to more es6 syntax

- Removed inherit & xtend dependencies for native alternativ
- Use es6 class, const, let
- Updated all dependencies
- Removed deprecated buffer construction for newer method